### PR TITLE
Reference Local Envoy Binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ test/envoye2e/http_metadata_exchange/testoutput
 *.wasm
 .vscode
 out/
+envoy/
 .cache

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,11 +33,16 @@ ENVOY_REPO = "envoy"
 
 # To override with local envoy, just pass `--override_repository=envoy=/PATH/TO/ENVOY` to Bazel or
 # persist the option in `user.bazelrc`.
-http_archive(
+# http_archive(
+#     name = "envoy",
+#     sha256 = ENVOY_SHA256,
+#     strip_prefix = ENVOY_REPO + "-" + ENVOY_SHA,
+#     url = "https://github.com/" + ENVOY_ORG + "/" + ENVOY_REPO + "/archive/" + ENVOY_SHA + ".tar.gz",
+# )
+
+local_repository(
     name = "envoy",
-    sha256 = ENVOY_SHA256,
-    strip_prefix = ENVOY_REPO + "-" + ENVOY_SHA,
-    url = "https://github.com/" + ENVOY_ORG + "/" + ENVOY_REPO + "/archive/" + ENVOY_SHA + ".tar.gz",
+    path = "envoy",
 )
 
 load("@envoy//bazel:api_binding.bzl", "envoy_api_binding")


### PR DESCRIPTION
With this change, the `proxy` workspace will expect to find the envoy source code locally, in a directory called `envoy` directly inside of the `proxy` repo. Any locally made changes to Envoy source code in this directory will be used when building Envoy with Proxy.